### PR TITLE
jenkinsci/jnlp-slave has been deprecated

### DIFF
--- a/exercises/part03-kubernetes-Jenkins.md
+++ b/exercises/part03-kubernetes-Jenkins.md
@@ -209,7 +209,7 @@ You should be able to connect to you Cluster by pressing `Test Connection`
 Click `Add Container` and provide the following information:
 
 - Name: jenkins-slave
-- Docker image: jenkinsci/jnlp-slave:3.26-1 **Note:** If the Slave *jnlp-slave:3.26-1* is not working for you, please replase it with`jenkinsci/jnlp-slave:alpine`
+- Docker image: jenkins/jnlp-slave:3.26-1 **Note:** If the Slave *jnlp-slave:3.26-1* is not working for you, please replase it with`jenkins/jnlp-slave:alpine`
 - *Leave the rest at their default value* 
 
 ![part03-k8sjenkins05](../images/part03-k8sjenkins05.png)/


### PR DESCRIPTION
per the jenkinsci/jnlp-slave description in hub.docker.com... Warning! This image used to be published as jenkinsci/jnlp-slave. That image name is deprecated, use jenkins/jnlp-slave.